### PR TITLE
fix: help display on parse errors

### DIFF
--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -28,6 +28,9 @@ const parsed = parse(
   // {
   //   help: true, // default: true
   //   helpWithNoArgs: true, // default: false
+  //   helpGenerator: (schema) => { // default: build-in help generator
+  //     return `Usage: ${process.argv[1]} [options] [args]`
+  //   }
   // }
 );
 

--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ function toZodShape<Options extends z.ZodRawShape, Flags extends z.ZodRawShape, 
 
 export function _parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape, Positional extends PositionalTuple>(schema: ZodCliSchema<Options, Flags, Positional>, args: string[]) {
   const obj = toObject(schema, args);
-  return toZodShape(schema).safeParse(obj);
+  return { result: toZodShape(schema).safeParse(obj), help: obj.flags.help as boolean ?? false };
 }
 
 export function parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape, Positional extends PositionalTuple>(schema: ZodCliSchema<Options, Flags, Positional>, args: string[], {help = true, helpWithNoArgs = false, helpGenerator = generateHelp }: { help?: boolean, helpWithNoArgs?: boolean, helpGenerator?: typeof generateHelp } = {}) {
@@ -105,7 +105,8 @@ export function parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape
     console.log(helpGenerator(schema as any), '');
     process.exit(0);
   }
-  const result = _parse(schema, args);
+
+  const { result, help: _help } = _parse(schema, args);
   if (result.success) {
     // @ts-ignore
     if (help && (result.data.flags.help || result.data.flags.h)) {
@@ -114,8 +115,13 @@ export function parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape
     }
     return result.data;
   } else {
-    reportError(result);
-    process.exit(1);
+    if (_help) {
+      console.log(helpGenerator(schema as any), '');
+      process.exit(0);
+    } else {
+      reportError(result);
+      process.exit(1);
+    }
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -100,16 +100,16 @@ export function _parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShap
   return toZodShape(schema).safeParse(obj);
 }
 
-export function parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape, Positional extends PositionalTuple>(schema: ZodCliSchema<Options, Flags, Positional>, args: string[], {help = true, helpWithNoArgs = false}: { help?: boolean, helpWithNoArgs?: boolean } = {}) {
+export function parse<Options extends z.ZodRawShape, Flags extends z.ZodRawShape, Positional extends PositionalTuple>(schema: ZodCliSchema<Options, Flags, Positional>, args: string[], {help = true, helpWithNoArgs = false, helpGenerator = generateHelp }: { help?: boolean, helpWithNoArgs?: boolean, helpGenerator?: typeof generateHelp } = {}) {
   if (helpWithNoArgs && args.length === 0) {
-    console.log(generateHelp(schema as any), '');
+    console.log(helpGenerator(schema as any), '');
     process.exit(0);
   }
   const result = _parse(schema, args);
   if (result.success) {
     // @ts-ignore
     if (help && (result.data.flags.help || result.data.flags.h)) {
-      console.log(generateHelp(schema as any), '');
+      console.log(helpGenerator(schema as any), '');
       process.exit(0);
     }
     return result.data;


### PR DESCRIPTION
This PR is based on #1
When the help option is available, help is displayed priority even if a parse error occurs.